### PR TITLE
Run code in readme as tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,8 @@ scalacOptions ++= Seq(
 
 libraryDependencies ++= {
   Seq(
-    "com.propensive" %% "magnolia" % "0.6.1",
-    "org.scalacheck" %% "scalacheck" % "1.13.4"
+    "com.propensive" %% "magnolia" % "0.7.0",
+    "org.scalacheck" %% "scalacheck" % "1.13.4",
+    "org.scalatest" %% "scalatest" % "3.0.4" % "test"
   )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,2 @@
+resolvers += Resolver.bintrayIvyRepo("zamblauskas", "sbt-plugins")
+addSbtPlugin("zamblauskas" % "sbt-examplestest" % "0.1.2")


### PR DESCRIPTION
This adds an sbt plugin that runs the code in the README as tests. Prevents typos as https://github.com/etaty/scalacheck-magnolia/pull/2